### PR TITLE
fixed missing h1 headers

### DIFF
--- a/support/free.rst
+++ b/support/free.rst
@@ -7,6 +7,8 @@ Please first read the docs, the existing issue tracker issues and mailing
 list posts -- a lot of stuff is already documented / explained / discussed /
 filed there.
 
+.. _issue_tracker:
+
 Issue Tracker
 -------------
 
@@ -15,8 +17,11 @@ ticket on the project's `issue tracker`_.
 
 For more general questions or discussions, IRC or mailing list are preferred.
 
+.. _chat_irc:
+
 Chat (IRC)
 ----------
+
 Join us on channel #borgbackup on chat.freenode.net.
 
 As usual on IRC, just ask or tell directly and then patiently wait for replies.
@@ -37,6 +42,8 @@ unsubscribe and where you can find the archives of the list, see the
 `mailing list homepage
 <https://mail.python.org/mailman/listinfo/borgbackup>`_.
 
+.. _twitter:
+
 Twitter
 -------
 
@@ -45,6 +52,8 @@ would like to get retweeted for a borg related tweet.
 
 Please understand that Twitter is not suitable for longer / more complex
 discussions - use one of the other channels for that.
+
+.. _bounties_and_fundraisers:
 
 Bounties and Fundraisers
 ------------------------


### PR DESCRIPTION
Fixed issue pointed out in a comment here: https://github.com/borgbackup/borg/issues/3332

somehow the h1 are not visible, so it looks very unstructured.

<img width="529" alt="screen shot 2017-11-25 at 10 39 21 pm" src="https://user-images.githubusercontent.com/9056242/33237165-847c2506-d231-11e7-9d8d-4357edf25d71.png">
