### PR TITLE
Revert "fixed broken links"

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -45,7 +45,7 @@ BorgBackup – Deduplicating archiver with compression and authenticated encrypt
         <div style="clear: both;"></div>
 
         <div class="link">
-            <a href="/support/free.html#bounties-and-fundraisers">
+            <a href="https://borgbackup.readthedocs.io/en/stable/support.html#bounties-and-fundraisers">
                 <span class="action">Fund</span><br>
                 development
             </a>

--- a/support/commercial.rst
+++ b/support/commercial.rst
@@ -3,20 +3,16 @@
 Paid Support and Services
 =========================
 
-Here are some commercial service and support providers for borgbackup:
+Here are some commercial service and support providers for borgbackup: 
 
-.. _commercial_support_and_services:
+::
 
-Commercial Support and Services
--------------------------------
+  company: Waldmann EDV Service GbR
+  contact: Thomas Waldmann <tw@waldmann-edv.de> 
+  scope: borgbackup consulting, support, development
 
+::
 
-company: Waldmann EDV Service GbR
-
-- contact: Thomas Waldmann <tw@waldmann-edv.de>
-- scope: borgbackup consulting, support, development
-
-company: rsync.net
-
-- service: `http://rsync.net/products/attic.html <http://rsync.net/products/attic.html>`_
-- scope: cloud storage platform with borg support
+  company: rsync.net
+  service: http://rsync.net/products/attic.html
+  scope: cloud storage platform with borg support

--- a/support/free.rst
+++ b/support/free.rst
@@ -13,7 +13,7 @@ Issue Tracker
 -------------
 
 If you've found a bug or have a concrete feature request, please create a new
-ticket on the project's `issue tracker <https://github.com/borgbackup/borg/issues>`_.
+ticket on the project's `issue tracker`_.
 
 For more general questions or discussions, IRC or mailing list are preferred.
 
@@ -68,7 +68,7 @@ the software / project you like.
 
 If you want to encourage developers to fix some specific issue or implement some
 specific feature suggestion, you can post a new bounty or back an existing one
-(they always refer to an issue in our `issue tracker <https://github.com/borgbackup/borg/issues>`_).
+(they always refer to an issue in our `issue tracker`_).
 
 As a developer, you can become a Bounty Hunter and win bounties (earn money) by
 contributing to Borg, a free and open source software project.


### PR DESCRIPTION
Reverts borgbackup/borgbackup.github.io#24

wrong branch, PR needs to be against "source" branch.