### PR TITLE
link to github for issues

### DIFF
--- a/support/free.rst
+++ b/support/free.rst
@@ -13,7 +13,8 @@ Issue Tracker
 -------------
 
 If you've found a bug or have a concrete feature request, please create a new
-ticket on the project's `issue tracker`_.
+ticket on the project's `issue tracker
+<https://www.github.com/borgbackup/borg/issues>`_.
 
 For more general questions or discussions, IRC or mailing list are preferred.
 


### PR DESCRIPTION
Previous link wasn't actually directing you to https://www.github.com/borgbackup/borg/issues