### PR TITLE
add time to videos

### DIFF
--- a/demo.rst
+++ b/demo.rst
@@ -16,13 +16,17 @@ Demo — BorgBackup
     <div id="demo">
         <h3>BorgBackup 1.1 - basic usage</h3>
         <asciinema-player src="_assets/asciicast-133292.json" speed="1.0"></asciinema-player>
+        6m 11s
         <hr>
         <h3>BorgBackup 1.1 - installation</h3>
         <asciinema-player src="_assets/asciicast-133291.json" speed="1.0"></asciinema-player>
+        1m 40s
         <hr>
         <h3>BorgBackup 1.1 - advanced usage</h3>
         <asciinema-player src="_assets/asciicast-133293.json" speed="1.0"></asciinema-player>
+        7m 9s
         <hr>
         <h3>BorgBackup 1.0 - installation and basic usage</h3>
         <asciinema-player src="_assets/asciinema-28691.json"  speed="1.5"></asciinema-player>
+        5m 30s
     </div>


### PR DESCRIPTION
See issue https://github.com/borgbackup/borgbackup.github.io/issues/27

Now present, but might not be in an ideal location. We can talk about that. 
Would you have rather seen written as 05:30?