### PR TITLE
Add borgbase.com to paid services

### DIFF
--- a/support/commercial.rst
+++ b/support/commercial.rst
@@ -23,3 +23,10 @@ Here are some commercial service and support providers for borgbackup:
   service: https://wiki.hetzner.de/index.php/BorgBackup/en
   scope: storage box with borg support
 
+::
+
+  company: borgbase.com
+  service: https://www.borgbase.com/
+  scope: specialized hosting for borg repositories. 100GB free during beta and for borg contributors.
+  
+::


### PR DESCRIPTION
I was surprised to see no specialized hosting service for borg that's easy to use and takes advantage of advanced features, like append-only mode. So here is my take on it. I'm giving 100gb backup space to all beta testers during public beta (until ~mid 2019) and most likely later to borg contributors if they should need it.

If there is enough interest, there could also be a GUI to make it easier to use for non-tech people. I had an intern who did something similar for another Python library during Google Summer of Code this year.