### PR TITLE
Use hyperlink to refer to external sites. Fixes #44

### DIFF
--- a/support/commercial.rst
+++ b/support/commercial.rst
@@ -5,26 +5,15 @@ Paid Support and Services
 
 Here are some commercial service and support providers for borgbackup: 
 
-::
+`Waldmann EDV Service GbR <https://waldmann-edv.de>`_
+  borgbackup consulting, support, development
 
-  company: Waldmann EDV Service GbR
-  contact: Thomas Waldmann <tw@waldmann-edv.de> 
-  scope: borgbackup consulting, support, development
+`rsync.net <https://www.rsync.net/products/borg.html>`_
+  cloud storage platform with borg support
 
-::
+`hetzner.de <https://wiki.hetzner.de/index.php/BorgBackup/en>`_
+  storage box with borg support
 
-  company: rsync.net
-  service: https://www.rsync.net/products/borg.html
-  scope: cloud storage platform with borg support
+`borgbase.com <https://www.borgbase.com/>`_
+  specialized hosting for borg repos
 
-::
-
-  company: hetzner.de
-  service: https://wiki.hetzner.de/index.php/BorgBackup/en
-  scope: storage box with borg support
-
-::
-
-  company: borgbase.com
-  service: https://www.borgbase.com/
-  scope: specialized hosting for borg repos

--- a/support/commercial.rst
+++ b/support/commercial.rst
@@ -5,15 +5,10 @@ Paid Support and Services
 
 Here are some commercial service and support providers for borgbackup: 
 
-`Waldmann EDV Service GbR <https://waldmann-edv.de>`_
-  borgbackup consulting, support, development
+- `Waldmann EDV Service GbR <mailto:tw@waldmann-edv.de>`_ - borgbackup consulting, support, development
 
-`rsync.net <https://www.rsync.net/products/borg.html>`_
-  cloud storage platform with borg support
+- `rsync.net <https://www.rsync.net/products/borg.html>`_ - cloud storage platform with borg support
 
-`hetzner.de <https://wiki.hetzner.de/index.php/BorgBackup/en>`_
-  storage box with borg support
+- `hetzner.de  <https://wiki.hetzner.de/index.php/BorgBackup/en>`_ - storage box with borg support
 
-`borgbase.com <https://www.borgbase.com/>`_
-  specialized hosting for borg repos
-
+- `borgbase.com <https://www.borgbase.com/>`_ - specialized hosting for borg repos


### PR DESCRIPTION
My first take. I changed yours to a link to the website too. To avoid your email being scraped. Very minimal, but I guess that was the plan.

<img width="696" alt="Screen Shot 2019-03-09 at 23 30 09" src="https://user-images.githubusercontent.com/3916435/54073549-74f85b00-42c3-11e9-8f86-2c4f44cd6baa.png">
