### PR TITLE
commercial: Remove mention of Hetzner services

### DIFF
--- a/support/commercial.rst
+++ b/support/commercial.rst
@@ -9,6 +9,4 @@ Here are some commercial service and support providers for borgbackup:
 
 - `rsync.net <https://www.rsync.net/products/borg.html>`_ - cloud storage platform with borg support
 
-- `hetzner.de <https://wiki.hetzner.de/index.php/BorgBackup/en>`_ - storage box with borg support
-
 - `borgbase.com <https://www.borgbase.com/>`_ - specialized hosting for borg repos


### PR DESCRIPTION
From Hetzner's website:

> Important note: From now on, you will only be able to deactivate the Backup Service feature. You will no longer be able to activate it. We will permanently discontinue this feature starting on 15 January 2020.

https://wiki.hetzner.de/index.php/BackupService/en