### PR TITLE
fix borked layout on landing page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -69,20 +69,20 @@ BorgBackup – Deduplicating archiver with compression and authenticated encrypt
     </div>
     <br>
     <div id="links">
-        <div class="link" style="width: 400px;">
+        <div class="link" style="width: 300px;">
             <a href="/support/free.html">
                 <span class="action">Receive</span><br>
                 free support
             </a>
         </div>
 
-        <div class="link" style="width: 400px;">
+        <div class="link" style="width: 299px;">
             <a href="/support/commercial.html">
                 <span class="action">Pay</span><br>
                 for services
             </a>
         </div>
     </div>
-    <br>
+    <br style="clear: both;">
 
     <em>... and always check your backups!</em>


### PR DESCRIPTION
Current:

![fullpage](https://user-images.githubusercontent.com/1330164/95676624-ba77bb00-0bbf-11eb-84d0-40323b0f788f.png)

This patch:

![fullpage](https://user-images.githubusercontent.com/1330164/95676639-ce232180-0bbf-11eb-8525-3511873864ed.png)

There's probably some flexbox-magic that could get the words evenly aligned in each row.