### PR TITLE
commercial: remove Lima-Labs

### DIFF
--- a/support/commercial.rst
+++ b/support/commercial.rst
@@ -13,5 +13,3 @@ Here are some commercial service and support providers for borgbackup:
 - `hetzner.de <https://wiki.hetzner.de/index.php/BorgBackup/en>`_ - storage box with borg support
 
 - `borgbase.com <https://www.borgbase.com/>`_ - specialized hosting for borg repos
-
-- `Lima-Labs <https://storage.lima-labs.com/>`_ - storage with borg support


### PR DESCRIPTION
remove lima-labs, since the service is shutting down, see: https://storage.lima-labs.com/2021/12/07/deciding-to-wind-down/