### PR TITLE
Small fixes

### DIFF
--- a/demo.rst
+++ b/demo.rst
@@ -9,7 +9,7 @@ Demo — BorgBackup
     <script type="text/javascript" src="_assets/asciinema-player-v2.4.1.js"></script>
     <noscript><p><strong>JavaScript is needed to view the demos.</strong></p></noscript>
 
-    <h2 id="tagline">Deduplicating archiver<br>with compression and encryption</h2>
+    <h2 id="tagline">Borg demos</h2>
 
     <p>All text in the following screencasts can be highlighted and copied!</p>
 

--- a/demo.rst
+++ b/demo.rst
@@ -9,24 +9,24 @@ Demo — BorgBackup
     <script type="text/javascript" src="_assets/asciinema-player-v2.4.1.js"></script>
     <noscript><p><strong>JavaScript is needed to view the demos.</strong></p></noscript>
 
-    <h2 id="tagline">Borg demos</h2>
+    <h1 id="tagline">Borg demos</h1>
 
     <p>All text in the following screencasts can be highlighted and copied!</p>
 
     <div id="demo">
-        <h3>BorgBackup 1.1 - basic usage</h3>
+        <h2>BorgBackup 1.1 - basic usage</h2>
         <asciinema-player src="_assets/asciicast-133292.json" speed="1.0"></asciinema-player>
         6m 11s
         <hr>
-        <h3>BorgBackup 1.1 - installation</h3>
+        <h2>BorgBackup 1.1 - installation</h2>
         <asciinema-player src="_assets/asciicast-133291.json" speed="1.0"></asciinema-player>
         1m 40s
         <hr>
-        <h3>BorgBackup 1.1 - advanced usage</h3>
+        <h2>BorgBackup 1.1 - advanced usage</h2>
         <asciinema-player src="_assets/asciicast-133293.json" speed="1.0"></asciinema-player>
         7m 9s
         <hr>
-        <h3>BorgBackup 1.0 - installation and basic usage</h3>
+        <h2>BorgBackup 1.0 - installation and basic usage</h2>
         <asciinema-player src="_assets/asciinema-28691.json"  speed="1.5"></asciinema-player>
         5m 30s
     </div>

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@ BorgBackup – Deduplicating archiver with compression and authenticated encrypt
 
 .. raw:: html
 
-    <h2 id="tagline">Deduplicating archiver<br>with compression and encryption</h2>
+    <h2 id="tagline">Deduplicating archiver with compression and encryption</h2>
 
     BorgBackup (short: Borg) gives you:
 

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@ BorgBackup – Deduplicating archiver with compression and authenticated encrypt
 
 .. raw:: html
 
-    <h2 id="tagline">Deduplicating archiver with compression and encryption</h2>
+    <h1 id="tagline">Deduplicating archiver with compression and encryption</h1>
 
     BorgBackup (short: Borg) gives you:
 

--- a/releases/index.rst
+++ b/releases/index.rst
@@ -63,6 +63,6 @@ releases from 0.23.0 to 0.30.1.
 
 
 Atom feed for releases
-======================
+----------------------
 
 https://github.com/borgbackup/borg/releases.atom


### PR DESCRIPTION
Addresses #96 

All issues fixed except editing the page titles (i.e. in `<head>`). It appears these are set by `rst2html5` based on the content of the first `h1`. A different title from the `h1` is achieved on the home and demo pages only because the main content is defined using raw html. A brief look at `rst2html5` [documentation](https://rst2html5.readthedocs.io/en/latest/) and at this project source files didn't present an easy solution to this. I'm not sure how to progress this point.

Headings were corrected on several pages additionally.
