### PR TITLE
index2: fix bottom counters showing wrong values without JS

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -1125,9 +1125,9 @@ noscript .hero-fallback {
   <p class="lead">Borg has protected production servers, research data and family photo
      archives for a decade. It is boring, in the best possible way.</p>
   <div class="counters">
-    <div class="counter"><div class="num"><span aria-hidden="true"><span data-count="10">0</span>+</span><span class="sr-only">10+</span></div><div class="what">years of development</div></div>
-    <div class="counter"><div class="num"><span aria-hidden="true"><span data-count="100">0</span>%</span><span class="sr-only">100%</span></div><div class="what">free software, BSD licensed</div></div>
-    <div class="counter"><div class="num"><span aria-hidden="true"><span data-count="0">7</span></span><span class="sr-only">0</span></div><div class="what">trust required in your server</div></div>
+    <div class="counter"><div class="num"><span aria-hidden="true"><span data-count="10" data-count-from="0">10</span>+</span><span class="sr-only">10+</span></div><div class="what">years of development</div></div>
+    <div class="counter"><div class="num"><span aria-hidden="true"><span data-count="100" data-count-from="0">100</span>%</span><span class="sr-only">100%</span></div><div class="what">free software, BSD licensed</div></div>
+    <div class="counter"><div class="num"><span aria-hidden="true"><span data-count="0" data-count-from="7">0</span></span><span class="sr-only">0</span></div><div class="what">trust required in your server</div></div>
   </div>
 </section>
 
@@ -1508,7 +1508,9 @@ if (!reduced) {
   // counters
   document.querySelectorAll('[data-count]').forEach((el) => {
     const target = parseInt(el.dataset.count, 10);
-    const obj = { v: el.textContent === '7' ? 7 : 0 };
+    const from = parseInt(el.dataset.countFrom, 10);
+    const obj = { v: from };
+    el.textContent = from;
     gsap.to(obj, {
       v: target, duration: 1.6, ease: 'power1.out',
       scrollTrigger: { trigger: el, start: 'top 85%' },


### PR DESCRIPTION
## Problem

The "trusted by sysadmins, hoarders and the merely paranoid" counters at the bottom of `index2.html` showed wrong values when JavaScript was disabled:

- **years of development**: `0+` instead of `10+`
- **free software, BSD licensed**: `0%` instead of `100%`
- **trust required in your server**: `7` instead of `0`

The visible (`aria-hidden`) spans held each animation's *starting* value and relied on the count-up JS to reach the real numbers, so with JS off the start values stayed on screen.

## Fix

- Put the correct **final** values (`10+`, `100%`, `0`) directly in the markup, so they're right with JS disabled.
- Added a `data-count-from` attribute carrying each animation's start value.
- The JS now reads `data-count-from` to set the start before animating to `data-count`, replacing the brittle `el.textContent === '7'` check.

Correct in all three cases: no JS, JS with animation, and `prefers-reduced-motion` (counter code is already skipped there, so the static markup is what shows).

## Verification

Served the page locally and checked both paths:

| Counter | No JS | JS animation (final) |
|---|---|---|
| years of development | `10+` | `10+` |
| free software, BSD licensed | `100%` | `100%` |
| trust required in your server | `0` | `0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)