### PR TITLE
index2: drop EOL release box, mark footer links as external

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -914,18 +914,6 @@ noscript .hero-fallback {
         <li><a class="ext" href="https://github.com/borgbackup/borg/releases">downloads</a></li>
       </ul>
     </div>
-    <div class="feature">
-      <h3>Borg 1.1, 1.0, 0.xx<span class="badge eol">end of life</span></h3>
-      <div class="ver">1.1.18 / 1.0.13</div>
-      <div class="when">2022-06-05 / 2019-02-15</div>
-      <p>No longer supported — please use Borg 1.4.x or 1.2.x. The 0.xx development
-         series (2015–2016) led up to Borg 1.0.</p>
-      <ul class="mini-links">
-        <li><a href="/releases/borg-1.1.html">1.1 announcement</a></li>
-        <li><a class="ext" href="https://borgbackup.readthedocs.io/en/1.1-maint/">1.1 docs</a></li>
-        <li><a class="ext" href="https://borgbackup.readthedocs.io/en/1.0-maint/">1.0 docs</a></li>
-      </ul>
-    </div>
   </div>
   <p class="aside">Borg&rsquo;s future:
      <a class="ext" href="https://github.com/borgbackup/borg/milestones">milestones</a> ·
@@ -1141,9 +1129,9 @@ noscript .hero-fallback {
     <a href="#support">Support</a>
     <a href="#services">Services</a>
     <a href="#fund">Fund</a>
-    <a href="https://borgbackup.readthedocs.io/">Docs</a>
-    <a href="https://github.com/borgbackup/community">Community</a>
-    <a href="https://github.com/borgbackup/borg">Contribute</a>
+    <a class="ext" href="https://borgbackup.readthedocs.io/">Docs</a>
+    <a class="ext" href="https://github.com/borgbackup/community">Community</a>
+    <a class="ext" href="https://github.com/borgbackup/borg">Contribute</a>
   </div>
   <p class="check">… and always check your backups!</p>
   <p class="legal">BorgBackup is free software, distributed under the BSD license.<br/>


### PR DESCRIPTION
Two small changes to `index2.html`:

### Remove the end-of-life release box
The install section no longer lists the **Borg 1.1 / 1.0 / 0.xx** "end of life" box. Only the supported series (1.4 stable, 1.2 oldstable) and the upcoming 2.0 testing series remain. The releases grid (`auto-fit`) reflows cleanly to three boxes.

### External-link indicator on footer links
The footer's **Docs / Community / Contribute** links now use `class="ext"`, so they get the same `↗` external-link indicator (via `a.ext::after`) as every other external link on the page. These were the only external links without an indicator — body links already had the `↗` arrow and the header nav links already had inline external-link icons.

Verified in a local preview: the install section shows three release boxes, and the footer links render the `↗` indicator while the internal anchors stay plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)