### PR TITLE
index2.html: fix fixed navbar overlapping hero content on mobile

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -161,7 +161,10 @@ header.top nav a svg { vertical-align: -1px; margin-left: 2px; }
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 6rem 1.5rem 4rem;
+  /* clear the fixed header: on mobile it wraps to several rows and grows
+     well past 6rem, so offset by its measured height (--header-h, set in JS)
+     to keep the logo/title from hiding behind it. Desktop keeps the 6rem look. */
+  padding: max(6rem, calc(var(--header-h, 62px) + 1.5rem)) 1.5rem 4rem;
 }
 
 .hero .logo svg {


### PR DESCRIPTION
## Problem

Reported in [discussion #9768](https://github.com/borgbackup/borg/discussions/9768#discussioncomment-17382142): on mobile the page title/logo is hidden behind the top nav bar, and scrolling up snaps back to it.

On narrow screens (`max-width: 640px`) the fixed `header.top` switches to a stacked column layout and the nav links wrap to several rows, so the header grows to **~170px** tall — well past the hero's fixed `6rem` (96px) top padding. Because the hero content is vertically centered, the logo and `h1` ended up sitting *behind* the fixed navbar.

## Fix

Offset the hero's top padding by the actual measured header height. `--header-h` is already computed in JS (used for section `scroll-margin-top`), so the hero now uses:

```css
padding: max(6rem, calc(var(--header-h, 62px) + 1.5rem)) 1.5rem 4rem;
```

- **Mobile:** header ≈170px → top padding becomes ~194px, content clears the navbar.
- **Desktop:** header is shorter than 6rem, so the `6rem` value still wins — look unchanged.

## Verification

Tested locally with a browser preview:

| Viewport | Header height | Hero top padding | Logo top | Overlap |
|----------|---------------|------------------|----------|---------|
| 375px (mobile) | 170px | 194px | 194px | none |
| 1280px (desktop) | 55px | 96px (6rem) | 104px | none |

🤖 Generated with [Claude Code](https://claude.com/claude-code)